### PR TITLE
Adding Mechanical.Aseprite project.

### DIFF
--- a/Mechanical.Aseprite/AsepriteFile.cs
+++ b/Mechanical.Aseprite/AsepriteFile.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * 
+ * This file is part of the Mechanical Game Engine and is licensed under the MIT license.
+ * https://github.com/OHGames/Mechanical
+ * 
+ * By O. H. Games
+ * 
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mehcanical.Aseprite
+{
+    /// <summary>
+    /// The Asprite File class represents an Asprite spritesheet export.
+    /// </summary>
+    /// <remarks>
+    /// This is not to be confused with <c>.ase</c> or <c>.aseprite</c> files.
+    /// </remarks>
+    public class AsepriteFile
+    {
+
+        /// <summary>
+        /// The directory of the file.
+        /// </summary>
+        public string FileDirectory { get; set; }
+
+        /// <summary>
+        /// The name of the file.
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// The name of the image that this Asprite file is made for.
+        /// </summary>
+        public string Image { get; }
+
+        /// <summary>
+        /// The frames in this file.
+        /// </summary>
+        public List<AspriteFrame> Frames { get; set; } = new List<AspriteFrame>();
+
+        /// <summary>
+        /// The frame tags in this file.
+        /// </summary>
+        public List<AsepriteFrameTag> FrameTags { get; set; } = new List<AsepriteFrameTag>();
+
+        /// <summary>
+        /// The slices in the file.
+        /// </summary>
+        public List<AsepriteSlice> Slices { get; set; } = new List<AsepriteSlice>();
+
+    }
+}

--- a/Mechanical.Aseprite/AsepriteFile.cs
+++ b/Mechanical.Aseprite/AsepriteFile.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical.Aseprite/AsepriteFile.cs
+++ b/Mechanical.Aseprite/AsepriteFile.cs
@@ -8,8 +8,10 @@
  * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
  */
 
+using Microsoft.Xna.Framework.Content;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace Mehcanical.Aseprite
@@ -36,12 +38,12 @@ namespace Mehcanical.Aseprite
         /// <summary>
         /// The name of the image that this Asprite file is made for.
         /// </summary>
-        public string Image { get; }
+        public string Image { get; set; }
 
         /// <summary>
         /// The frames in this file.
         /// </summary>
-        public List<AspriteFrame> Frames { get; set; } = new List<AspriteFrame>();
+        public List<AsepriteFrame> Frames { get; set; } = new List<AsepriteFrame>();
 
         /// <summary>
         /// The frame tags in this file.
@@ -53,5 +55,55 @@ namespace Mehcanical.Aseprite
         /// </summary>
         public List<AsepriteSlice> Slices { get; set; } = new List<AsepriteSlice>();
 
+        /// <summary>
+        /// The layers in the file.
+        /// </summary>
+        public List<AsepriteLayer> Layers { get; set; } = new List<AsepriteLayer>();
+
+        
+        /// <summary>
+        /// Load an Aseprite file.
+        /// </summary>
+        /// <param name="content">The content manager.</param>
+        /// <param name="path">The path relative to the content folder specified in <see cref="ContentManager.RootDirectory"/>.</param>
+        /// <returns>A new <see cref="AsepriteFile"/>.</returns>
+        public static AsepriteFile Load(ContentManager content, string path)
+        {
+            return Load($"{Environment.CurrentDirectory}/{content.RootDirectory}/{path}.json");
+        }
+
+        /// <summary>
+        /// Load an Aseprite file.
+        /// </summary>
+        /// <param name="path">The path to the file.</param>
+        /// <returns>A new <see cref="AsepriteFile"/>.</returns>
+        public static AsepriteFile Load(string path)
+        {
+            // get the content.
+            string fileContent = File.ReadAllText(path);
+
+            return AsepriteParser.Parse(fileContent);
+        }
+
     }
+
+    /// <summary>
+    /// Extensions.
+    /// </summary>
+    public static class ContentManagerExtensions
+    {
+
+        /// <summary>
+        /// Load an Aseprite file.
+        /// </summary>
+        /// <param name="manager">The content manager.</param>
+        /// <param name="path">The path relative to the content folder specified in <see cref="ContentManager.RootDirectory"/>.</param>
+        /// <returns>A new <see cref="AsepriteFile"/>.</returns>
+        public static AsepriteFile Load(this ContentManager manager, string path)
+        {
+            return AsepriteFile.Load(manager, path);
+        }
+
+    }
+
 }

--- a/Mechanical.Aseprite/AsepriteFile.cs
+++ b/Mechanical.Aseprite/AsepriteFile.cs
@@ -12,6 +12,7 @@ using Microsoft.Xna.Framework.Content;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Mehcanical.Aseprite
@@ -82,7 +83,102 @@ namespace Mehcanical.Aseprite
             // get the content.
             string fileContent = File.ReadAllText(path);
 
-            return AsepriteParser.Parse(fileContent);
+            AsepriteFile file = AsepriteParser.Parse(fileContent);
+
+            file.FileDirectory = path;
+            file.FileName = Path.GetFileNameWithoutExtension(path);
+
+            return file;
+        }
+
+        /// <summary>
+        /// Get the layers of the file.
+        /// </summary>
+        /// <returns>The layers.</returns>
+        public IEnumerable<AsepriteLayer> GetLayers() => new List<AsepriteLayer>(Layers);
+
+        /// <summary>
+        /// Get the frames of the file.
+        /// </summary>
+        /// <returns>The frames.</returns>
+        public IEnumerable<AsepriteFrame> GetFrames() => new List<AsepriteFrame>(Frames);
+
+        /// <summary>
+        /// Get the frame tags of the file.
+        /// </summary>
+        /// <returns>The frame tags.</returns>
+        public IEnumerable<AsepriteFrameTag> GetFrameTags() => new List<AsepriteFrameTag>(FrameTags);
+
+        /// <summary>
+        /// Get the slices.
+        /// </summary>
+        /// <returns>The slices.</returns>
+        public IEnumerable<AsepriteSlice> GetSlices() => new List<AsepriteSlice>(Slices);
+
+        /// <summary>
+        /// Gets a frame tag based on its name.
+        /// </summary>
+        /// <param name="name">The name of the tag.</param>
+        /// <returns>An <see cref="AsepriteFrameTag"/>.</returns>
+        /// <exception cref="ArgumentException">When the frame <paramref name="name"/> is not in the file.</exception>
+        public AsepriteFrameTag GetFrameTag(string name)
+        {
+            // there should only be one of the name so get the first.
+            AsepriteFrameTag tag = FrameTags.Where(t => t.Name.ToLower() == name.ToLower()).FirstOrDefault();
+            
+            // if the tag was not found.
+            if (tag.Name == null)
+            {
+                throw new ArgumentException($"The frame tag name, {name}, is not valid.");
+            }
+            else
+            {
+                return tag;
+            }
+        }
+
+        /// <summary>
+        /// Gets a slice based on its name.
+        /// </summary>
+        /// <param name="name">The name of the slice.</param>
+        /// <returns>An <see cref="AsepriteSlice"/></returns>
+        /// <exception cref="ArgumentException">When the slice <paramref name="name"/> is not in the file.</exception>
+        public AsepriteSlice GetSlice(string name)
+        {
+            // there should only be one so get the first.
+            AsepriteSlice slice = Slices.Where(s => s.Name.ToLower() == name.ToLower()).FirstOrDefault();
+
+            // if the slice was not found.
+            if (slice.Name == null)
+            {
+                throw new ArgumentException($"The slice name, {name}, is not valid.");
+            }
+            else
+            {
+                return slice;
+            }
+        }
+
+        /// <summary>
+        /// Gets a layer based on its name.
+        /// </summary>
+        /// <param name="name">The name of the layer.</param>
+        /// <returns>An <see cref="AsepriteLayer"/></returns>
+        /// <exception cref="ArgumentException">When the layer <paramref name="name"/> is not in the file.</exception>
+        public AsepriteLayer GetLayer(string name)
+        {
+            // there should only be one so get the first.
+            AsepriteLayer layer = Layers.Where(l => l.Name.ToLower() == name.ToLower()).FirstOrDefault();
+
+            // if the layer was not found.
+            if (layer.Name == null)
+            {
+                throw new ArgumentException($"The layer name, {name}, is not valid.");
+            }
+            else
+            {
+                return layer;
+            }
         }
 
     }

--- a/Mechanical.Aseprite/AsepriteFrame.cs
+++ b/Mechanical.Aseprite/AsepriteFrame.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical.Aseprite/AsepriteFrame.cs
+++ b/Mechanical.Aseprite/AsepriteFrame.cs
@@ -18,7 +18,7 @@ namespace Mehcanical.Aseprite
     /// <summary>
     /// The Aseprite Frame struct represents a frame from an <see cref="AsepriteFile"/>.
     /// </summary>
-    public struct AspriteFrame
+    public struct AsepriteFrame
     {
 
         /// <summary>

--- a/Mechanical.Aseprite/AsepriteLayer.cs
+++ b/Mechanical.Aseprite/AsepriteLayer.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Mechanical;

--- a/Mechanical.Aseprite/AsepriteLayer.cs
+++ b/Mechanical.Aseprite/AsepriteLayer.cs
@@ -8,6 +8,7 @@
  * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
  */
 
+using Mechanical;
 using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
@@ -40,6 +41,11 @@ namespace Mehcanical.Aseprite
         /// The opacity of the layer.
         /// </summary>
         public int Opacity { get; set; }
+
+        /// <summary>
+        /// The normalized opacity is the opacity between 0 and 1.
+        /// </summary>
+        public float NormalizedOpacity => Opacity.Normalize(0, 255);
 
         /// <summary>
         /// The blend mode of the layer.

--- a/Mechanical.Aseprite/AsepriteLayer.cs
+++ b/Mechanical.Aseprite/AsepriteLayer.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * 
+ * This file is part of the Mechanical Game Engine and is licensed under the MIT license.
+ * https://github.com/OHGames/Mechanical
+ * 
+ * By O. H. Games
+ * 
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ */
+
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mehcanical.Aseprite
+{
+    /// <summary>
+    /// The Aseprite Layer struct represents an Aseprite layer.
+    /// </summary>
+    public struct AsepriteLayer
+    {
+
+        /// <summary>
+        /// The name of the layer.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The color of the layer.
+        /// </summary>
+        public Color Color { get; set; }
+
+        /// <summary>
+        /// The user data.
+        /// </summary>
+        public string UserData { get; set; }
+
+        /// <summary>
+        /// The opacity of the layer.
+        /// </summary>
+        public int Opacity { get; set; }
+
+        /// <summary>
+        /// The blend mode of the layer.
+        /// </summary>
+        public string BlendMode { get; set; }
+
+    }
+}

--- a/Mechanical.Aseprite/AsepriteParser.cs
+++ b/Mechanical.Aseprite/AsepriteParser.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Mechanical;

--- a/Mechanical.Aseprite/AsepriteParser.cs
+++ b/Mechanical.Aseprite/AsepriteParser.cs
@@ -49,6 +49,8 @@ namespace Mehcanical.Aseprite
             // get slices
             file.Slices = LoadSlices(meta);
 
+            file.Image = (string)mainObject["frames"][0]["filename"];
+
             // return
             return file;
         }
@@ -120,6 +122,7 @@ namespace Mehcanical.Aseprite
                     Direction = (AsepriteFrameTagDirection)Enum.Parse(typeof(AsepriteFrameTagDirection), (string)obj["direction"], true),
                     Start = (int)obj["from"],
                     End = (int)obj["to"],
+                    Name = (string)obj["name"]
                 };
 
                 tags.Add(tag);
@@ -153,10 +156,13 @@ namespace Mehcanical.Aseprite
                 };
 
                 // get color.
-                string color = (string)CheckIfValueExists("color", layer);
-                aLayer.Color = ColorHelper.FromHexRGBA(color);
+                string color = (string)layer["color"];
+                if (color != null)
+                {
+                    aLayer.Color = ColorHelper.FromHexRGBA(color);
+                }
 
-                aLayer.UserData = (string)CheckIfValueExists("data", layer);
+                aLayer.UserData = (string)layer["data"] ?? "";
 
                 list.Add(aLayer);
             }
@@ -185,7 +191,7 @@ namespace Mehcanical.Aseprite
                 {
                     Color = ColorHelper.FromHexRGBA((string)slice["color"]),
                     Name = (string)slice["name"],
-                    UserData = (string)CheckIfValueExists((string)slice["data"], slice)
+                    UserData = (string)slice["data"] ?? ""
                 };
 
                 aSlice.Keys = LoadSliceKeys(slice);
@@ -223,13 +229,13 @@ namespace Mehcanical.Aseprite
                     )
                 };
 
-                JObject pivot = (JObject)CheckIfValueExists("pivot", key);
+                JObject pivot = (JObject)key["pivot"];
                 if (pivot != null)
                 {
                     aKey.Pivot = new Vector2((float)pivot["x"], (float)pivot["y"]);
                 }
 
-                JObject nineSlice = (JObject)CheckIfValueExists("center", key);
+                JObject nineSlice = (JObject)key["center"];
                 if (nineSlice != null)
                 {
                     aKey.NineSlice = new Rectangle(
@@ -247,24 +253,5 @@ namespace Mehcanical.Aseprite
             return list;
 
         }
-
-        /// <summary>
-        /// Check if the value exists.
-        /// </summary>
-        /// <param name="name">The name of the variable.</param>
-        /// <param name="obj">The object to get from.</param>
-        /// <returns></returns>
-        private static object CheckIfValueExists(string name, JObject obj)
-        {
-            try
-            {
-                return obj[name];
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
     }
 }

--- a/Mechanical.Aseprite/AsepriteParser.cs
+++ b/Mechanical.Aseprite/AsepriteParser.cs
@@ -1,0 +1,124 @@
+﻿/*
+ * 
+ * This file is part of the Mechanical Game Engine and is licensed under the MIT license.
+ * https://github.com/OHGames/Mechanical
+ * 
+ * By O. H. Games
+ * 
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ */
+
+using Microsoft.Xna.Framework;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mehcanical.Aseprite
+{
+    /// <summary>
+    /// The Aseprite parser takes the <see cref="JObject"/> povided by the <see cref="AsepriteFile"/> 
+    /// and returns a new <see cref="AsepriteFile"/> from it.
+    /// </summary>
+    internal static class AsepriteParser
+    {
+
+        /// <summary>
+        /// Parse the JSON.
+        /// </summary>
+        /// <param name="json">The JSON to parse.</param>
+        /// <returns>A new <see cref="AsepriteFile"/>.</returns>
+        public static AsepriteFile Parse(string json)
+        {
+
+            // parse the JSON.
+            JObject mainObject = JObject.Parse(json);
+
+            // make the new file.
+            AsepriteFile file = new AsepriteFile();
+
+            // get the frames first.
+            file.Frames = LoadFrames(mainObject);
+
+            file.FrameTags = LoadFrameTags((JObject)mainObject["meta"]);
+
+        }
+
+        /// <summary>
+        /// Load the frames from the <see cref="JObject"/>.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="AsepriteFrame"/>s.</returns>
+        private static List<AsepriteFrame> LoadFrames(JObject obj)
+        {
+            // get the "frames" array.
+            JArray frames = (JArray)obj["frames"];
+
+            List<AsepriteFrame> newList = new List<AsepriteFrame>();
+
+            // loop through frames.
+            for (int i = 0; i < frames.Count; i++)
+            {
+                // the frame object.
+                JObject frame = (JObject)frames[i];
+
+                AsepriteFrame aFrame = new AsepriteFrame()
+                {
+                    // the duration
+                    FrameDuration = (int)frame["duration"],
+                    // the frame.
+                    FrameRect = new Rectangle(
+                        (int)frame["frame"]["x"],
+                        (int)frame["frame"]["y"],
+                        (int)frame["frame"]["w"],
+                        (int)frame["frame"]["h"]
+                    ),
+                    // the initial size of the frame.
+                    SpriteSourceSize = new Rectangle(
+                        (int)frame["spriteSourceSize"]["x"],
+                        (int)frame["spriteSourceSize"]["y"],
+                        (int)frame["spriteSourceSize"]["w"],
+                        (int)frame["spriteSourceSize"]["h"]
+                    )
+                };
+
+                newList.Add(aFrame);
+            }
+
+            return newList;
+
+        }
+
+        /// <summary>
+        /// Load the <see cref="AsepriteFrameTag"/>s.
+        /// </summary>
+        /// <param name="meta">The meta object.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="AsepriteFrameTag"/>s.</returns>
+        private static List<AsepriteFrameTag> LoadFrameTags(JObject meta)
+        {
+            // get the array.
+            JArray array = (JArray)meta["frameTags"];
+            List<AsepriteFrameTag> tags = new List<AsepriteFrameTag>();
+
+            for (int i = 0; i < array.Count; i++)
+            {
+                // get object.
+                JObject obj = (JObject)array[i];
+
+                AsepriteFrameTag tag = new AsepriteFrameTag()
+                {
+                    // get the enum name.
+                    Direction = (AsepriteFrameTagDirection)Enum.Parse(typeof(AsepriteFrameTagDirection), (string)obj["direction"], true),
+                    Start = (int)obj["from"],
+                    End = (int)obj["to"],
+                };
+
+                tags.Add(tag);
+
+            }
+
+            return tags;
+        }
+
+    }
+}

--- a/Mechanical.Aseprite/AsepriteSlice.cs
+++ b/Mechanical.Aseprite/AsepriteSlice.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical.Aseprite/AsepriteSlice.cs
+++ b/Mechanical.Aseprite/AsepriteSlice.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * 
+ * This file is part of the Mechanical Game Engine and is licensed under the MIT license.
+ * https://github.com/OHGames/Mechanical
+ * 
+ * By O. H. Games
+ * 
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ */
+
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mehcanical.Aseprite
+{
+    /// <summary>
+    /// The Aseprite Slice struct represents an Aseprite slice.
+    /// </summary>
+    public struct AsepriteSlice
+    {
+
+        /// <summary>
+        /// The name of the slice.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The color of the slice.
+        /// </summary>
+        public Color Color { get; set; }
+
+        /// <summary>
+        /// Some user-specified data about this slice.
+        /// </summary>
+        public string UserData { get; set; }
+
+        /// <summary>
+        /// The keys of this slice.
+        /// </summary>
+        public List<AsepriteSliceKey> Keys { get; set; }
+
+    }
+
+    /// <summary>
+    /// The slice information for specific frames.
+    /// </summary>
+    public struct AsepriteSliceKey
+    {
+        /// <summary>
+        /// The 0-based index of the frame that this information is for.
+        /// </summary>
+        public int Frame { get; set; }
+
+        /// <summary>
+        /// The slice's shape.
+        /// </summary>
+        public Rectangle Bounds { get; set; }
+
+        /// <summary>
+        /// The pivot point of the slice.
+        /// </summary>
+        public Vector2 Pivot { get; set; }
+
+        /// <summary>
+        /// The 9-sclice center of the sprite.
+        /// </summary>
+        public Rectangle NineSlice { get; set; }
+    }
+
+}

--- a/Mechanical.Aseprite/AspriteFrame.cs
+++ b/Mechanical.Aseprite/AspriteFrame.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * 
+ * This file is part of the Mechanical Game Engine and is licensed under the MIT license.
+ * https://github.com/OHGames/Mechanical
+ * 
+ * By O. H. Games
+ * 
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ */
+
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mehcanical.Aseprite
+{
+    /// <summary>
+    /// The Aseprite Frame struct represents a frame from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    public struct AspriteFrame
+    {
+
+        /// <summary>
+        /// The rectangle that represents this frame on the image.
+        /// </summary>
+        public Rectangle FrameRect { get; set; }
+
+        /// <summary>
+        /// The sprite source size. (initial image size)
+        /// </summary>
+        public Rectangle SpriteSourceSize { get; set; }
+
+        /// <summary>
+        /// The frame duration in miliseconds.
+        /// </summary>
+        public int FrameDuration { get; set; }
+
+        /// <summary>
+        /// The frame duration in seconds.
+        /// </summary>
+        public float FrameDurationInSeconds => FrameDuration / 1000;
+
+    }
+}

--- a/Mechanical.Aseprite/AspriteFrameTag.cs
+++ b/Mechanical.Aseprite/AspriteFrameTag.cs
@@ -34,6 +34,11 @@ namespace Mehcanical.Aseprite
         /// </summary>
         public int End { get; set; }
 
+        /// <summary>
+        /// The name of the tag.
+        /// </summary>
+        public string Name { get; set; }
+
     }
 
     /// <summary>

--- a/Mechanical.Aseprite/AspriteFrameTag.cs
+++ b/Mechanical.Aseprite/AspriteFrameTag.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * 
+ * This file is part of the Mechanical Game Engine and is licensed under the MIT license.
+ * https://github.com/OHGames/Mechanical
+ * 
+ * By O. H. Games
+ * 
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mehcanical.Aseprite
+{
+    /// <summary>
+    /// The Aseprite Tag is a struct that represents Asprite's frame tag system.
+    /// </summary>
+    public struct AsepriteFrameTag
+    {
+        /// <summary>
+        /// The direction of the tag.
+        /// </summary>
+        public AsepriteFrameTagDirection Direction { get; set; }
+
+        /// <summary>
+        /// What frame the tag starts on (0-based index).
+        /// </summary>
+        public int Start { get; set; }
+
+        /// <summary>
+        /// What frame the tag ends on (0-based index).
+        /// </summary>
+        public int End { get; set; }
+
+    }
+
+    /// <summary>
+    /// The direction a <see cref="AsepriteFrameTag"/> can move in.
+    /// </summary>
+    public enum AsepriteFrameTagDirection
+    {
+        /// <summary>
+        /// The animation goes forward.
+        /// </summary>
+        Forward,
+
+        /// <summary>
+        /// The animation goes backward.
+        /// </summary>
+        Reverse,
+
+        /// <summary>
+        /// The animation will play forward then play backward when it reaches the end.
+        /// </summary>
+        PingPong
+    }
+
+}

--- a/Mechanical.Aseprite/AspriteFrameTag.cs
+++ b/Mechanical.Aseprite/AspriteFrameTag.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical.Aseprite/Mehcanical.Aseprite.csproj
+++ b/Mechanical.Aseprite/Mehcanical.Aseprite.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mechanical\Mechanical.csproj" />
+  </ItemGroup>
+</Project>

--- a/Mechanical.Aseprite/Mehcanical.Aseprite.csproj
+++ b/Mechanical.Aseprite/Mehcanical.Aseprite.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mechanical\Mechanical.csproj" />

--- a/Mechanical.Aseprite/Mehcanical.Aseprite.csproj
+++ b/Mechanical.Aseprite/Mehcanical.Aseprite.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641">

--- a/Mechanical.sln
+++ b/Mechanical.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mechanical", "Mechanical\Mechanical.csproj", "{905879B5-6B38-4115-AE1C-8A522D584BA3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mehcanical.Aseprite", "Mechanical.Aseprite\Mehcanical.Aseprite.csproj", "{8014339D-A277-47E7-A6EC-196F6F08569B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{905879B5-6B38-4115-AE1C-8A522D584BA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{905879B5-6B38-4115-AE1C-8A522D584BA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{905879B5-6B38-4115-AE1C-8A522D584BA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8014339D-A277-47E7-A6EC-196F6F08569B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8014339D-A277-47E7-A6EC-196F6F08569B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8014339D-A277-47E7-A6EC-196F6F08569B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8014339D-A277-47E7-A6EC-196F6F08569B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Mechanical/Animation/SpriteAnimation.cs
+++ b/Mechanical/Animation/SpriteAnimation.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Animation/SpriteAnimationEvent.cs
+++ b/Mechanical/Animation/SpriteAnimationEvent.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Collision/Collision.cs
+++ b/Mechanical/Collision/Collision.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Collision/Responses/CircleCollisionResponse.cs
+++ b/Mechanical/Collision/Responses/CircleCollisionResponse.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Collision/Responses/ICollisionResponse.cs
+++ b/Mechanical/Collision/Responses/ICollisionResponse.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Collision/Responses/PolygonCollisionResponse.cs
+++ b/Mechanical/Collision/Responses/PolygonCollisionResponse.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Collision/Responses/RectangleCollisionResponse.cs
+++ b/Mechanical/Collision/Responses/RectangleCollisionResponse.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Console/Console.cs
+++ b/Mechanical/Console/Console.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Console/ConsoleCommandAttribute.cs
+++ b/Mechanical/Console/ConsoleCommandAttribute.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Console/ConsoleMessageType.cs
+++ b/Mechanical/Console/ConsoleMessageType.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Console/ConsoleWindow.cs
+++ b/Mechanical/Console/ConsoleWindow.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/ECS/Attributes/NeedsComponentAttribute.cs
+++ b/Mechanical/ECS/Attributes/NeedsComponentAttribute.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/ECS/Component.cs
+++ b/Mechanical/ECS/Component.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/ECS/Components/Animation/SpriteAnimatorComponent.cs
+++ b/Mechanical/ECS/Components/Animation/SpriteAnimatorComponent.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/ECS/Components/SpriteComponent.cs
+++ b/Mechanical/ECS/Components/SpriteComponent.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/ECS/Components/Transform.cs
+++ b/Mechanical/ECS/Components/Transform.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/ECS/Entity.cs
+++ b/Mechanical/ECS/Entity.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/ECS/Lists/ComponentList.cs
+++ b/Mechanical/ECS/Lists/ComponentList.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/ECS/Lists/EntityList.cs
+++ b/Mechanical/ECS/Lists/EntityList.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/ECS/Lists/GameLikeList.cs
+++ b/Mechanical/ECS/Lists/GameLikeList.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/ECS/Scene.cs
+++ b/Mechanical/ECS/Scene.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/ECS/Transitions/SceneTransition.cs
+++ b/Mechanical/ECS/Transitions/SceneTransition.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  * 
  * Thanks to this tutorial series: https://manbeardgames.com/docs/tutorials/monogame-3-8/scene-transitions/introduction
  * Some changes made.

--- a/Mechanical/Engine.cs
+++ b/Mechanical/Engine.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Graphics/Drawing.cs
+++ b/Mechanical/Graphics/Drawing.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/Graphics/GUI/Built-In/GUIAnimatedImage.cs
+++ b/Mechanical/Graphics/GUI/Built-In/GUIAnimatedImage.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Graphics/GUI/Built-In/GUIImage.cs
+++ b/Mechanical/Graphics/GUI/Built-In/GUIImage.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Graphics/GUI/Built-In/GUIText.cs
+++ b/Mechanical/Graphics/GUI/Built-In/GUIText.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Graphics;

--- a/Mechanical/Graphics/GUI/GUICanvas.cs
+++ b/Mechanical/Graphics/GUI/GUICanvas.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Graphics/GUI/GUIElement.cs
+++ b/Mechanical/Graphics/GUI/GUIElement.cs
@@ -6,7 +6,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Graphics/GUI/GUIElementList.cs
+++ b/Mechanical/Graphics/GUI/GUIElementList.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/Graphics/IDrawable.cs
+++ b/Mechanical/Graphics/IDrawable.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 using System;
 using System.Collections.Generic;

--- a/Mechanical/Graphics/IDrawableComponent.cs
+++ b/Mechanical/Graphics/IDrawableComponent.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 using System;
 using System.Collections.Generic;

--- a/Mechanical/Graphics/RenderLayer.cs
+++ b/Mechanical/Graphics/RenderLayer.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Graphics/Screen.cs
+++ b/Mechanical/Graphics/Screen.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Input/Keybind.cs
+++ b/Mechanical/Input/Keybind.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Input/Keybinds.cs
+++ b/Mechanical/Input/Keybinds.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Input/MechAxis.cs
+++ b/Mechanical/Input/MechAxis.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Input/MechController.cs
+++ b/Mechanical/Input/MechController.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Input;

--- a/Mechanical/Input/MechKeyboard.cs
+++ b/Mechanical/Input/MechKeyboard.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Input;

--- a/Mechanical/Input/MechMouse.cs
+++ b/Mechanical/Input/MechMouse.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/Camera.cs
+++ b/Mechanical/Misc/Camera.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/Extensions/ColorHelper.cs
+++ b/Mechanical/Misc/Extensions/ColorHelper.cs
@@ -209,18 +209,18 @@ namespace Mechanical
         {
             // flip the last 2 digits to make it RGBA -> ARGB.
             // remove #
-            hex = hex.Remove(0);
+            hex = hex.Remove(0, 1);
             // convert alpha chars to strings.
             string alpha = $"{hex[hex.Length - 2]}{hex[hex.Length - 1]}";
             // remove last 2 alpha digits
             // do same thing twice because when it removes the last one, the length changes so we remove the last one again.
-            hex = hex.Remove(hex.Length - 1);
-            hex = hex.Remove(hex.Length - 1);
+            hex = hex.Remove(hex.Length - 1, 1);
+            hex = hex.Remove(hex.Length - 1, 1);
             // put alpha onto begining.
             hex = alpha + hex;
             // convert to system color
             // https://stackoverflow.com/a/2109938
-            System.Drawing.Color c = System.Drawing.Color.FromArgb(Convert.ToInt32(hex));
+            System.Drawing.Color c = System.Drawing.Color.FromArgb(Convert.ToInt32(hex, 16));
             // return color.
             return new Color(c.R, c.G, c.B, c.A);
         }

--- a/Mechanical/Misc/Extensions/ColorHelper.cs
+++ b/Mechanical/Misc/Extensions/ColorHelper.cs
@@ -19,7 +19,7 @@ namespace Mechanical
     /// <summary>
     /// Extensions for <see cref="Color"/>
     /// </summary>
-    public static class ColorExtensions
+    public static class ColorHelper
     {
         /// <summary>
         /// A list of colors and their names.
@@ -198,6 +198,44 @@ namespace Mechanical
         {
             // we use Colors.Count because max is exclusive.
             return Colors.GetKey(new Random().Next(0, Colors.Count));
+        }
+
+        /// <summary>
+        /// Turns a hex code into a color.
+        /// </summary>
+        /// <param name="hex">The hex color in RGBA format.</param>
+        /// <returns>A new <see cref="Color"/> from the hex.</returns>
+        public static Color FromHexRGBA(string hex)
+        {
+            // flip the last 2 digits to make it RGBA -> ARGB.
+            // remove #
+            hex = hex.Remove(0);
+            // convert alpha chars to strings.
+            string alpha = $"{hex[hex.Length - 2]}{hex[hex.Length - 1]}";
+            // remove last 2 alpha digits
+            // do same thing twice because when it removes the last one, the length changes so we remove the last one again.
+            hex = hex.Remove(hex.Length - 1);
+            hex = hex.Remove(hex.Length - 1);
+            // put alpha onto begining.
+            hex = alpha + hex;
+            // convert to system color
+            // https://stackoverflow.com/a/2109938
+            System.Drawing.Color c = System.Drawing.Color.FromArgb(Convert.ToInt32(hex));
+            // return color.
+            return new Color(c.R, c.G, c.B, c.A);
+        }
+
+        /// <summary>
+        /// Turns a hex code into a color.
+        /// </summary>
+        /// <param name="hex">The hex color in ARGB format.</param>
+        /// <returns>A new <see cref="Color"/> from the hex.</returns>
+        public static Color FromHex(string hex)
+        {
+            // convert to system color
+            System.Drawing.Color c = System.Drawing.Color.FromArgb(Convert.ToInt32(hex));
+            // return color.
+            return new Color(c.R, c.G, c.B, c.A);
         }
 
     }

--- a/Mechanical/Misc/Extensions/ColorHelper.cs
+++ b/Mechanical/Misc/Extensions/ColorHelper.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/Extensions/DictionaryExtensions.cs
+++ b/Mechanical/Misc/Extensions/DictionaryExtensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 

--- a/Mechanical/Misc/Extensions/EnumerableExtensions.cs
+++ b/Mechanical/Misc/Extensions/EnumerableExtensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/Extensions/FloatAndIntExtensions.cs
+++ b/Mechanical/Misc/Extensions/FloatAndIntExtensions.cs
@@ -100,8 +100,8 @@ namespace Mechanical
         /// Normalize a number from zero to one.
         /// </summary>
         /// <param name="num">The number to normalize.</param>
-        /// <param name="min">The max number.</param>
-        /// <param name="max">The min number.</param>
+        /// <param name="min">The min number.</param>
+        /// <param name="max">The max number.</param>
         /// <returns>A number between zero and one.</returns>
         //https://www.statology.org/normalize-data-between-0-and-1/
         public static float Normalize(this float num, float min, float max)
@@ -113,8 +113,8 @@ namespace Mechanical
         /// Normalize a number from zero to one.
         /// </summary>
         /// <param name="num">The number to normalize.</param>
-        /// <param name="min">The max number.</param>
-        /// <param name="max">The min number.</param>
+        /// <param name="min">The min number.</param>
+        /// <param name="max">The max number.</param>
         /// <returns>A number between zero and one.</returns>
         //https://www.statology.org/normalize-data-between-0-and-1/
         public static int Normalize(this int num, int min, int max)

--- a/Mechanical/Misc/Extensions/FloatAndIntExtensions.cs
+++ b/Mechanical/Misc/Extensions/FloatAndIntExtensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/Extensions/ObjectExtensions.cs
+++ b/Mechanical/Misc/Extensions/ObjectExtensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/Extensions/ShapeExtensions.cs
+++ b/Mechanical/Misc/Extensions/ShapeExtensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/Extensions/StringExtensions.cs
+++ b/Mechanical/Misc/Extensions/StringExtensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/Extensions/Vector2Extensions.cs
+++ b/Mechanical/Misc/Extensions/Vector2Extensions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/IDManager.cs
+++ b/Mechanical/Misc/IDManager.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/IGameFunctions.cs
+++ b/Mechanical/Misc/IGameFunctions.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework.Content;

--- a/Mechanical/Misc/IParentChildHierarchy.cs
+++ b/Mechanical/Misc/IParentChildHierarchy.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/MechMath.cs
+++ b/Mechanical/Misc/MechMath.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Misc/Shapes/Circle.cs
+++ b/Mechanical/Misc/Shapes/Circle.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/Shapes/LineSegment.cs
+++ b/Mechanical/Misc/Shapes/LineSegment.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/Shapes/Polygon.cs
+++ b/Mechanical/Misc/Shapes/Polygon.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Misc/WeightedList.cs
+++ b/Mechanical/Misc/WeightedList.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Particle System/IParticleSpawner.cs
+++ b/Mechanical/Particle System/IParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Particle.cs
+++ b/Mechanical/Particle System/Particle.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/ParticleSystem.cs
+++ b/Mechanical/Particle System/ParticleSystem.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/BasicParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/BasicParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/CircleParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/CircleParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/IncrementDirection.cs
+++ b/Mechanical/Particle System/Spawners/IncrementDirection.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Particle System/Spawners/IncrementalCircleParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/IncrementalCircleParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/IncrementalRectangleParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/IncrementalRectangleParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/InnerCircleParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/InnerCircleParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/LineSegmentParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/LineSegmentParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Particle System/Spawners/RectangleParticleSpawner.cs
+++ b/Mechanical/Particle System/Spawners/RectangleParticleSpawner.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Serialization/Content Importers/SpriteAnimationLoader.cs
+++ b/Mechanical/Serialization/Content Importers/SpriteAnimationLoader.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Serialization/Serializer.cs
+++ b/Mechanical/Serialization/Serializer.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using System;

--- a/Mechanical/Tiles/Tile.cs
+++ b/Mechanical/Tiles/Tile.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;

--- a/Mechanical/Tiles/Tilemap.cs
+++ b/Mechanical/Tiles/Tilemap.cs
@@ -5,7 +5,7 @@
  * 
  * By O. H. Games
  * 
- * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/USED_CODE_LICENSES.txt for more info.
+ * Note: some files contain code from other sources so see https://github.com/OHGames/Mechanical/blob/main/Use%20Code%20Licenses.md for more info.
  */
 
 using Microsoft.Xna.Framework;


### PR DESCRIPTION
## Adding Mechanical.Aseprite Project.
The `Mechanical.Aseprite` project is a project used to load [Aseprite Sprite Sheet Files](https://www.aseprite.org/docs/sprite-sheet/).

It contains a main file called `AsepriteFile` in the `Mechanical.Aseprite` namespace. The file has some static loading functions and some instance functions to get specific data.